### PR TITLE
Use Elasticsearch for Job Normalization

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -12,6 +12,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate, MigrateCommand
 from flask_restful import Api
 from flask_cors import CORS, cross_origin
+from flask.ext.elasticsearch import FlaskElasticsearch
 
 # ----------------------------------------------------------------------------
 # Flask Application Configuration
@@ -30,6 +31,7 @@ api = Api(app, catch_all_404s=True)
 # ----------------------------------------------------------------------------
 db = SQLAlchemy(app)
 migrate = Migrate(app, db)
+es = FlaskElasticsearch(app)
 
 from api.router import api_bp as api_router_blueprint
 from api.v1 import api_bp as api_1_blueprint

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,9 @@ Flask-Migrate==1.8.1
 Flask-RESTful==0.3.5
 Flask-Script==2.0.5
 Flask-SQLAlchemy==2.1
+Flask-Elasticsearch
 futures==3.0.5
+HTTPretty
 hjson==1.5.6
 idna==2.1
 ipaddress==1.0.16
@@ -26,6 +28,7 @@ jmespath==0.9.0
 lambda-packages==0.5.0
 Mako==1.0.4
 MarkupSafe==0.23
+mock
 ndg-httpsclient==0.4.1
 psycopg2==2.6.1
 pyasn1==0.1.9

--- a/tests/es_nohit_output.json
+++ b/tests/es_nohit_output.json
@@ -1,0 +1,1 @@
+{"took":86,"timed_out":false,"_shards":{"total":1,"successful":1,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}

--- a/tests/es_normalize_output.json
+++ b/tests/es_normalize_output.json
@@ -1,0 +1,70 @@
+{
+   "hits":{
+      "hits":[
+         {
+            "_score":4.096966,
+            "_type":"titles",
+            "_id":"-12345",
+            "fields":{
+               "title":[
+                  "Sales Managers"
+               ]
+            },
+            "_index":"normalizer"
+         },
+         {
+            "_score":4.0939603,
+            "_type":"titles",
+            "_id":"23456",
+            "fields":{
+               "title":[
+                  "Sales Managers"
+               ]
+            },
+            "_index":"normalizer"
+         },
+         {
+            "_score":4.0939603,
+            "_type":"titles",
+            "_id":"-34567",
+            "fields":{
+               "title":[
+                  "Sales Managers"
+               ]
+            },
+            "_index":"normalizer"
+         },
+         {
+            "_score":4.0794497,
+            "_type":"titles",
+            "_id":"-45678",
+            "fields":{
+               "title":[
+                  "Sales Managers"
+               ]
+            },
+            "_index":"normalizer"
+         },
+         {
+            "_score":2.1334965,
+            "_type":"titles",
+            "_id":"56789",
+            "fields":{
+               "title":[
+                  "First-Line Supervisors/Managers of Non-Retail Sales Workers"
+               ]
+            },
+            "_index":"normalizer"
+         }
+      ],
+      "total":922009,
+      "max_score":4.096966
+   },
+   "_shards":{
+      "successful":1,
+      "failed":0,
+      "total":1
+   },
+   "took":443,
+   "timed_out":false
+}

--- a/tests/job_normalize_test.py
+++ b/tests/job_normalize_test.py
@@ -1,0 +1,62 @@
+from app import app
+import httpretty
+import json
+import re
+import unittest
+
+
+class JobNormalizeTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.app = app.app.test_client()
+        self.app.testing = True
+
+    def mock_endpoint_with_response(self, source_filename):
+        httpretty.HTTPretty.allow_net_connect = False
+        url_regex = 'http://{}/.*'.format(app.app.config['ELASTICSEARCH_HOST'])
+        with open(source_filename) as f:
+            output = f.read()
+        httpretty.register_uri(
+            httpretty.GET,
+            re.compile(url_regex),
+            body=output,
+            content_type='application/json'
+        )
+
+    @httpretty.activate
+    def test_with_hits(self):
+        self.mock_endpoint_with_response('tests/es_normalize_output.json')
+        response = self.app.get('v1/jobs/normalize?job_title=cupcake+ninja')
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.get_data())
+        self.assertEqual(len(response_data), 1)
+        self.assertEqual(response_data[0]['title'], 'Sales Managers')
+
+    @httpretty.activate
+    def test_with_defined_limit(self):
+        self.mock_endpoint_with_response('tests/es_normalize_output.json')
+        response = self.app.get('v1/jobs/normalize?job_title=cupcake+ninja&limit=2')
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.get_data())
+        self.assertEqual(len(response_data), 2)
+        self.assertEqual(
+            response_data[1]['title'],
+            'First-Line Supervisors/Managers of Non-Retail Sales Workers'
+        )
+
+    @httpretty.activate
+    def test_no_hits(self):
+        self.mock_endpoint_with_response('tests/es_nohit_output.json')
+        response = self.app.get('v1/jobs/normalize?job_title=baker')
+        self.assertEqual(response.status_code, 404)
+
+    def test_no_title(self):
+        response = self.app.get('v1/jobs/normalize')
+        self.assertEqual(response.status_code, 400)
+
+    def test_bad_limit(self):
+        response = self.app.get('v1/jobs/normalize?job_title=test&limit=999999')
+        self.assertEqual(response.status_code, 400)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Add requirements for Elasticsearch and mocking HTTP endpoints in tests
- Initialize Elasticsearch connection from repo config in Flask setup
- Modify Job Normalization endpoint to query Elasticsearch, and optionally grab ONET categories
- Add Elasticsearch example json files for successful and unsuccessful normalization queries
- Add unit test for Job Normalization endpoint